### PR TITLE
Made rectangle parameter optional & automatically calculate width/height.

### DIFF
--- a/src/org/villekoskela/utils/RectanglePacker.as
+++ b/src/org/villekoskela/utils/RectanglePacker.as
@@ -175,28 +175,28 @@ package org.villekoskela.utils
                     mInsertedRectangles[mInsertedRectangles.length] = target;
                 }
 
-                mHeight = 0;
-                mWidth = 0;
-                
-                var length:int = mInsertedRectangles.length;
-                var rect:IntegerRectangle;
-                
-                for (var i:int = 0; i < length; i++)
-                {
-                	rect = mInsertedRectangles[i];
-                	
-                	if (rect.y + rect.height > mHeight)
-                	{
-                		mHeight = rect.y + rect.height;
-                	}
-                	
-                	if (rect.x + rect.width > mWidth)
-                	{
-                		mWidth = rect.x + rect.width;
-                	}
-                }
-
                 freeSize(sortableSize);
+            }
+
+            mHeight = 0;
+            mWidth = 0;
+            
+            var length:int = mInsertedRectangles.length;
+            var rect:IntegerRectangle;
+            
+            for (var i:int = 0; i < length; i++)
+            {
+                rect = mInsertedRectangles[i];
+            	
+            	if (rect.y + rect.height > mHeight)
+            	{
+            		mHeight = rect.y + rect.height;
+            	}
+            	
+            	if (rect.x + rect.width > mWidth)
+            	{
+            		mWidth = rect.x + rect.width;
+            	}
             }
 
             return rectangleCount;

--- a/src/org/villekoskela/utils/RectanglePacker.as
+++ b/src/org/villekoskela/utils/RectanglePacker.as
@@ -100,7 +100,7 @@ package org.villekoskela.utils
          * @param rectangle an instance where to set the rectangle's values
          * @return
          */
-        public function getRectangle(index:int, rectangle:Rectangle):Rectangle
+        public function getRectangle(index:int, rectangle:Rectangle = null):Rectangle
         {
             var inserted:IntegerRectangle = mInsertedRectangles[index];
             if (rectangle)

--- a/src/org/villekoskela/utils/RectanglePacker.as
+++ b/src/org/villekoskela/utils/RectanglePacker.as
@@ -61,7 +61,7 @@ package org.villekoskela.utils
          * @param width the width of the main rectangle
          * @param height the height of the main rectangle
          */
-        public function RectanglePacker(width:int, height:int)
+        public function RectanglePacker(width:int = 2048, height:int = 2048)
         {
             mOutsideRectangle = new IntegerRectangle(width + 1, height + 1, 0, 0);
             reset(width, height);
@@ -175,10 +175,41 @@ package org.villekoskela.utils
                     mInsertedRectangles[mInsertedRectangles.length] = target;
                 }
 
+                mHeight = 0;
+                mWidth = 0;
+                
+                var length:int = mInsertedRectangles.length;
+                var rect:IntegerRectangle;
+                
+                for (var i:int = 0; i < length; i++)
+                {
+                	rect = mInsertedRectangles[i];
+                	
+                	if (rect.y + rect.height > mHeight)
+                	{
+                		mHeight = rect.y + rect.height;
+                	}
+                	
+                	if (rect.x + rect.width > mWidth)
+                	{
+                		mWidth = rect.x + rect.width;
+                	}
+                }
+
                 freeSize(sortableSize);
             }
 
             return rectangleCount;
+        }
+
+        public function get height():int
+        {
+        	return mHeight;
+        }
+        
+        public function get width():int
+        {
+        	return mWidth;
         }
 
         /**

--- a/src/org/villekoskela/utils/RectanglePacker.as
+++ b/src/org/villekoskela/utils/RectanglePacker.as
@@ -54,7 +54,9 @@ package org.villekoskela.utils
         private var mSortableSizeStack:Vector.<SortableSize> = new Vector.<SortableSize>();
         private var mRectangleStack:Vector.<IntegerRectangle> = new Vector.<IntegerRectangle>();
 
+        public function get height():int { return mHeight; }
         public function get rectangleCount():int { return mInsertedRectangles.length; }
+        public function get width():int { return mWidth; }
 
         /**
          * Constructs new rectangle packer
@@ -200,16 +202,6 @@ package org.villekoskela.utils
             }
 
             return rectangleCount;
-        }
-
-        public function get height():int
-        {
-        	return mHeight;
-        }
-        
-        public function get width():int
-        {
-        	return mWidth;
         }
 
         /**


### PR DESCRIPTION
You check to see if `rectangle` is `null` in `getRectangle()` so I'm guessing you forgot to set the parameter's default value to `null`. Fixed.

Also added the feature to make it so that, after packing, you can access special `width` and `height` getters that retrieve the smallest possible values in order to house every single rectangle. Useful if you need to know what size to set a texture/`RenderTexture` object in Starling.
